### PR TITLE
Sync internal sheet dismissal back to the activeModal binding in Select

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,5 @@ jobs:
       - build-tvOS-example
       - build-watchOS-example
       - test-iOS-example
-
     uses: oversizedev/GithubWorkflows/.github/workflows/bump.yml@main
     secrets: inherit

--- a/Sources/OversizeUI/Controls/Select/MultiSelect.swift
+++ b/Sources/OversizeUI/Controls/Select/MultiSelect.swift
@@ -95,13 +95,21 @@ public struct MultiSelect<Element: Equatable, Content: View, Selection: View, Ac
                 modal
                 #endif
             }
-            .onChange(of: showModalBinding) { state in
-                if let state {
-                    showModal = state
+            .onChange(of: showModalBinding) { _, newValue in
+                if let newValue, newValue != showModal {
+                    showModal = newValue
+                }
+            }
+            .onChange(of: showModal) { _, newValue in
+                if showModalBinding != nil, showModalBinding != newValue {
+                    showModalBinding = newValue
                 }
             }
         }
         .onAppear {
+            if let showModalBinding, showModalBinding != showModal {
+                showModal = showModalBinding
+            }
             if !selection.isEmpty {
                 for dataIndex in 0 ..< data.count {
                     let dataItem = data[dataIndex]

--- a/Sources/OversizeUI/Controls/Select/Select.swift
+++ b/Sources/OversizeUI/Controls/Select/Select.swift
@@ -88,6 +88,9 @@ public struct Select<Element: Equatable, Content: View, Selection: View, Actions
             }
         }
         .onAppear {
+            if let showModalBinding, showModalBinding != showModal {
+                showModal = showModalBinding
+            }
             updateSelectionState()
         }
         .onChange(of: data) {

--- a/Sources/OversizeUI/Controls/Select/Select.swift
+++ b/Sources/OversizeUI/Controls/Select/Select.swift
@@ -77,9 +77,14 @@ public struct Select<Element: Equatable, Content: View, Selection: View, Actions
                 #endif
             }
         }
-        .onChange(of: showModalBinding) { state in
-            if let state {
-                showModal = state
+        .onChange(of: showModalBinding) { _, newValue in
+            if let newValue, newValue != showModal {
+                showModal = newValue
+            }
+        }
+        .onChange(of: showModal) { _, newValue in
+            if showModalBinding != nil, showModalBinding != newValue {
+                showModalBinding = newValue
             }
         }
         .onAppear {


### PR DESCRIPTION
Select kept the `activeModal` binding one-way: internal dismiss paths (row selection, the Close button, swipe-down) wrote only the private `showModal` state, leaving the external binding stale, so the next tap on the field reset the binding instead of opening the sheet. This adds the reverse `onChange` with inequality guards on both directions, so every dismiss path syncs back without ping-ponging; behaviour with the default `.constant(nil)` is unchanged. Note for a follow-up: `MultiSelect` has the same one-way sync, and `SelectPicker` accepts `activeModal` but silently ignores it.