### PR TITLE
Fix cover layouts rendering on macOS

### DIFF
--- a/Sources/OversizeUI/Layouts/CoverLayout/CoverLayout.swift
+++ b/Sources/OversizeUI/Layouts/CoverLayout/CoverLayout.swift
@@ -69,8 +69,11 @@ public struct CoverLayout<
                 }
                 .padding(.top, contentOffset)
             }
+            #if os(macOS)
+            .contentMargins(.top, coverHeight, for: .scrollContent)
+            #else
             .safeAreaPadding(.top, coverHeight)
-            // .contentMargins(.top, resolveContentMarginTop, for: .scrollContent)
+            #endif
             .onScrollGeometryChange(for: CGFloat.self) { proxy in
                 proxy.contentOffset.y + proxy.contentInsets.top
             } action: { _, value in
@@ -82,6 +85,7 @@ public struct CoverLayout<
             background
                 .ignoresSafeArea()
         }
+        .modifier(CoverScrollEdgeEffectModifier())
     }
 
     private var coverStretchHeight: CGFloat {
@@ -131,6 +135,20 @@ public struct CoverLayout<
         self.contentBackground = contentBackground()
         self.coverBackground = coverBackground()
         self.background = background()
+    }
+}
+
+private struct CoverScrollEdgeEffectModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        #if os(macOS)
+        if #available(macOS 26.0, *) {
+            content.scrollEdgeEffectHidden(true, for: .top)
+        } else {
+            content
+        }
+        #else
+        content
+        #endif
     }
 }
 

--- a/Sources/OversizeUI/Layouts/ListCoverLayout/ListCoverLayout.swift
+++ b/Sources/OversizeUI/Layouts/ListCoverLayout/ListCoverLayout.swift
@@ -47,6 +47,19 @@ public struct ListCoverLayout<
                     .offset(y: coverScrollOffset)
 
                 SwiftUI.List(selection: $selection) {
+                    #if os(macOS)
+                    Color.clear
+                        .frame(height: spacerRowHeight)
+                        .listRowInsets(EdgeInsets())
+                        .listRowBackground(Color.clear)
+                        .listRowSeparator(.hidden)
+                        .selectionDisabled()
+                        .background {
+                            ListScrollOffsetReader { offset in
+                                scrollOffset = offset
+                            }
+                        }
+                    #endif
                     SwiftUI.Group(sections: content) { sections in
                         SwiftUI.ForEach(sections) { section in
                             ListLayoutSectionView(section: section)
@@ -58,12 +71,14 @@ public struct ListCoverLayout<
                 .environment(\.defaultMinListHeaderHeight, 40)
                 .environment(\.defaultMinListRowHeight, 56)
                 .scrollContentBackground(.hidden)
+                #if !os(macOS)
                 .contentMargins(.top, resolveContentMarginTop, for: .scrollContent)
                 .onScrollGeometryChange(for: CGFloat.self) { proxy in
                     proxy.contentOffset.y + proxy.contentInsets.top
                 } action: { _, value in
                     scrollOffset = value
                 }
+                #endif
             }
             .background(backgroundView.ignoresSafeArea())
         }
@@ -121,6 +136,12 @@ public struct ListCoverLayout<
     private var coverScrollOffset: CGFloat {
         scrollOffset > 0 ? -scrollOffset : 0
     }
+
+    #if os(macOS)
+    private var spacerRowHeight: CGFloat {
+        max(0, resolveContentMarginTop)
+    }
+    #endif
 
     private var resolveContentMarginTop: CGFloat {
         if let contentMarginTop {

--- a/Sources/OversizeUI/Layouts/ListCoverLayout/OffsetReader/ListScrollOffsetReader.swift
+++ b/Sources/OversizeUI/Layouts/ListCoverLayout/OffsetReader/ListScrollOffsetReader.swift
@@ -72,13 +72,20 @@ struct ListScrollOffsetReader: NSViewRepresentable {
 @available(macOS 14.0, *)
 final class ListScrollOffsetNSView: NSView {
     var onScroll: (@MainActor (CGFloat) -> Void)?
-    private var observation: NSKeyValueObservation?
+    private nonisolated(unsafe) var observer: NSObjectProtocol?
+    private weak var observedScrollView: NSScrollView?
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        guard window != nil, observation == nil else { return }
+        guard window != nil, observer == nil else { return }
         DispatchQueue.main.async { [weak self] in
             self?.observeScrollView()
+        }
+    }
+
+    deinit {
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
         }
     }
 
@@ -86,15 +93,27 @@ final class ListScrollOffsetNSView: NSView {
         var current: NSView? = self
         while let view = current {
             if let scrollView = view as? NSScrollView {
-                observation = scrollView.contentView.observe(\.bounds, options: .new) { [weak self] clipView, _ in
-                    MainActor.assumeIsolated {
-                        guard let self else { return }
-                        self.onScroll?(clipView.bounds.origin.y)
-                    }
-                }
+                observe(scrollView)
                 return
             }
             current = view.superview
+        }
+    }
+
+    private func observe(_ scrollView: NSScrollView) {
+        observedScrollView = scrollView
+        let clipView = scrollView.contentView
+        clipView.postsBoundsChangedNotifications = true
+        observer = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: clipView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, let scrollView = self.observedScrollView else { return }
+                let offset = scrollView.contentView.bounds.origin.y + scrollView.contentInsets.top
+                self.onScroll?(offset)
+            }
         }
     }
 }


### PR DESCRIPTION
On macOS the system Liquid Glass scroll edge effect blurred the whole cover area of CoverLayout, because safeAreaPadding inflated the top safe area; the layout now insets content with contentMargins on macOS so the glass stays within the toolbar. ListCoverLayout rows also rendered behind the cover and ignored scrolling, since contentMargins and onScrollGeometryChange do not work for AppKit-backed List; a spacer row plus an NSScrollView bounds observer restore the intended behavior. iOS, tvOS and watchOS code paths are unchanged.