### PR TITLE
Deprecate screenSize modifiers and environment key while keeping them working

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ The old page and navigation stack is deprecated in favour of native SwiftUI navi
 | `ScrollViewOffset` | `ScrollViewWithOffsetTracking` |
 | `.rowArrow()` | `.navigatable()` |
 | `.shadow(elevation:)` | `.shadowElevation(_:)` |
+| `.screenSize(_:)` modifiers | `@Environment(\.screenSize)` resolves itself; `GeometryReader` / `.onGeometryChange` for container sizes |
 | `.screenSize` safe-area accessors | `@Environment(\.safeAreaInsets)` |
 
 ## Example App

--- a/Sources/OversizeUI/Controls/DateField/DatePickerSheet.swift
+++ b/Sources/OversizeUI/Controls/DateField/DatePickerSheet.swift
@@ -11,7 +11,6 @@ import SwiftUI
 @available(watchOS, unavailable)
 @available(tvOS, unavailable)
 public struct DatePickerSheet: View {
-    @Environment(\.screenSize) var screenSize
     @Environment(\.dismiss) var dismiss
 
     @Binding private var selection: Date

--- a/Sources/OversizeUI/Controls/HUD/HUD.swift
+++ b/Sources/OversizeUI/Controls/HUD/HUD.swift
@@ -6,8 +6,6 @@
 import SwiftUI
 
 public struct HUD<Title: View, Icon: View>: View {
-    @Environment(\.screenSize) var screenSize
-
     private let content: HUDContent<Title, Icon>
     private let isAutoHide: Bool
 

--- a/Sources/OversizeUI/Controls/Toast/Snackbar.swift
+++ b/Sources/OversizeUI/Controls/Toast/Snackbar.swift
@@ -6,8 +6,6 @@
 import SwiftUI
 
 public struct Snackbar<Label: View, Actions: View>: View {
-    @Environment(\.screenSize) var screenSize
-
     private let text: String?
 
     private let label: Label?

--- a/Sources/OversizeUI/Core/EnvironmentKeys/ScreenEnvironment.swift
+++ b/Sources/OversizeUI/Core/EnvironmentKeys/ScreenEnvironment.swift
@@ -76,6 +76,7 @@ public struct ScreenSize: Sendable {
 // MARK: - EnvironmentValues
 
 public extension EnvironmentValues {
+    @available(*, deprecated, message: "Use GeometryReader or onGeometryChange to read the size and safe area of the container")
     @Entry var screenSize: ScreenSize = {
         #if os(iOS) || os(tvOS)
         return MainActor.assumeIsolated {
@@ -163,16 +164,4 @@ public extension EnvironmentValues {
         return SwiftUI.EdgeInsets()
         #endif
     }()
-}
-
-// MARK: - View Extensions
-
-public extension View {
-    func screenSize(_ size: ScreenSize) -> some View {
-        environment(\.screenSize, size)
-    }
-
-    func screenSize(_ geometry: GeometryProxy) -> some View {
-        environment(\.screenSize, ScreenSize(geometry: geometry))
-    }
 }

--- a/Sources/OversizeUI/Deprecated/Layouts/CalendarLayoutView/CalendarLayoutView.swift
+++ b/Sources/OversizeUI/Deprecated/Layouts/CalendarLayoutView/CalendarLayoutView.swift
@@ -17,7 +17,6 @@ public struct CalendarLayoutView<
 >: View {
     @Environment(\.sizeCategory) private var contentSize
     @Environment(\.calendar) private var calendar
-    @Environment(\.safeAreaInsets) private var safeAreaInsets
 
     public typealias ScrollAction = @MainActor @Sendable (_ offset: CGPoint, _ headerVisibleRatio: CGFloat) -> Void
 
@@ -35,6 +34,7 @@ public struct CalendarLayoutView<
     @State private var calendarHeight: CGFloat?
 
     @State private var isShowMonthPicker: Bool = false
+    @State private var headerHeight: CGFloat = 0
 
     private var columns: [GridItem] {
         Array(repeating: GridItem(spacing: 0), count: 7)
@@ -87,6 +87,19 @@ public struct CalendarLayoutView<
             }
         }
         .background(background.ignoresSafeArea())
+        .background {
+            Color.clear
+                .ignoresSafeArea()
+                .onGeometryChange(for: CGFloat.self) { proxy in
+                    proxy.safeAreaInsets.top + 44
+                } action: { height in
+                    let isInitial = headerHeight == 0
+                    headerHeight = height
+                    if isInitial {
+                        onScroll?(.zero, 1.0)
+                    }
+                }
+        }
         .toolbarTitleDisplayMode(.inline)
         .sensoryFeedback(.selection, trigger: selection)
         .sheet(isPresented: $isShowMonthPicker) {
@@ -231,7 +244,7 @@ public struct CalendarLayoutView<
     }
 
     private func handleScrollOffset(_ offset: CGPoint) {
-        let headerHeight = 44 + safeAreaInsets.top
+        guard headerHeight > 0 else { return }
         let visibleRatio: CGFloat = (headerHeight + offset.y) / headerHeight
         onScroll?(offset, visibleRatio)
     }

--- a/Sources/OversizeUI/Deprecated/PageView.swift
+++ b/Sources/OversizeUI/Deprecated/PageView.swift
@@ -8,8 +8,6 @@ import SwiftUI
 @available(*, deprecated, renamed: "LayoutView")
 @available(iOS 15.0, macOS 14, tvOS 15.0, watchOS 9.0, *)
 public struct PageView<Content: View, LeadingBar: View, TrailingBar: View, TopToolbar: View, TitleLabel: View>: View {
-    @Environment(\.screenSize) var screenSize
-
     private let title: String?
     private let content: Content
     private var isLargeTitle = false

--- a/Sources/OversizeUI/Deprecated/ScreenSizeDeprecated.swift
+++ b/Sources/OversizeUI/Deprecated/ScreenSizeDeprecated.swift
@@ -1,0 +1,18 @@
+//
+// Copyright © 2021 Alexander Romanov
+// ScreenSizeDeprecated.swift, created on 10.09.2026
+//
+
+import SwiftUI
+
+public extension View {
+    @available(*, deprecated, message: "Do not inject ScreenSize into the environment: @Environment(\\.screenSize) resolves the value itself. Use GeometryReader or onGeometryChange for container-specific sizes")
+    func screenSize(_ size: ScreenSize) -> some View {
+        environment(\.screenSize, size)
+    }
+
+    @available(*, deprecated, message: "Do not inject ScreenSize into the environment: @Environment(\\.screenSize) resolves the value itself. Use GeometryReader or onGeometryChange for container-specific sizes")
+    func screenSize(_ geometry: GeometryProxy) -> some View {
+        environment(\.screenSize, ScreenSize(geometry: geometry))
+    }
+}


### PR DESCRIPTION
The `.screenSize(_:)` modifiers and the `\.screenSize` environment key are now marked deprecated, while the live default value stays intact so existing `@Environment(\.screenSize)` readers keep getting real screen size and safe area values. Injecting the value from `SystemServices` via `.screenSize(geometry)` over the HUD root is what collapsed the accessibility tree, so the modifier is what consumers should stop using. Also removes unused `screenSize` environment reads from `Snackbar`, `HUD`, `DatePickerSheet` and `PageView`, and switches `CalendarLayoutView` to measure the header via `onGeometryChange` instead of the environment.